### PR TITLE
fix: add missing LastSnapshotStorage trait methods

### DIFF
--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -115,6 +115,14 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getOrdinal: F[Option[SnapshotOrdinal]] = get.map(_.map(_.ordinal))
 
+      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        logger.info(s"[FileBasedLastGlobalIncrementalSnapshotStorage] Recovery reset at ordinal=${snapshot.ordinal}") >>
+          set(snapshot, state)
+
+      def clear: F[Unit] =
+        logger.info("[FileBasedLastGlobalIncrementalSnapshotStorage] Clearing for recovery download") >>
+          cachedSnapshot.set(None)
+
       def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
       def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = {

--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -115,6 +115,7 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getOrdinal: F[Option[SnapshotOrdinal]] = get.map(_.map(_.ordinal))
 
+      def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
       def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = {
         val snapshotWithState = SnapshotWithState(snapshot, state)

--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -117,6 +117,12 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
+      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+        set(snapshot, state)
+
+      def clear: F[Unit] =
+        cachedSnapshot.set(None)
+
     }
 
 }

--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -117,11 +117,20 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
-      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
-        set(snapshot, state)
+      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = {
+        val snapshotWithState = SnapshotWithState(snapshot, state)
+        saveSnapshotWithStateJson(path, snapshotWithState) >> cachedSnapshot.set(Some(snapshotWithState))
+      }
 
-      def clear: F[Unit] =
-        cachedSnapshot.set(None)
+      def clear: F[Unit] = {
+        val backupPath = Path(path.toString + ".bk")
+        val deleteFile = (p: Path) =>
+          Files[F].deleteIfExists(p).void.handleErrorWith {
+            case _: java.nio.file.NoSuchFileException => Async[F].unit
+            case e                                    => Async[F].raiseError(e)
+          }
+        cachedSnapshot.set(None) >> deleteFile(path) >> deleteFile(backupPath)
+      }
 
     }
 

--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -115,15 +115,6 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getOrdinal: F[Option[SnapshotOrdinal]] = get.map(_.map(_.ordinal))
 
-      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
-        logger.info(s"[FileBasedLastGlobalIncrementalSnapshotStorage] Recovery reset at ordinal=${snapshot.ordinal}") >>
-          set(snapshot, state)
-
-      def clear: F[Unit] =
-        logger.info("[FileBasedLastGlobalIncrementalSnapshotStorage] Clearing for recovery download") >>
-          cachedSnapshot.set(None)
-
-      def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
       def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = {
         val snapshotWithState = SnapshotWithState(snapshot, state)


### PR DESCRIPTION
Tessellation's `LastSnapshotStorage` trait added `setForRecovery` and `clear` methods for fork recovery support (PR constellation-labs/tessellation#1476). Snapshot-streaming must implement these to compile against the updated SDK.

- `setForRecovery`: delegates to `set` (no special recovery handling needed for indexer)
- `clear`: resets the cached snapshot ref