### PR TITLE
feat: store state and combined snapshot+state in S3 with configurable retention

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -25,6 +25,9 @@ snapshotStreaming {
   opensearch {}
   s3 {
     uploadEnabled = false
+    uploadStateEnabled = false
+    uploadCombinedEnabled = false
+    retentionCount = 1000
   }
 }
 

--- a/src/main/scala/org/constellation/snapshotstreaming/Configuration.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/Configuration.scala
@@ -35,7 +35,16 @@ final case class DbConfig(
 )
 
 final case class S3ApiConfig(endpoint: Option[String], region: Option[String], pathStyleEnabled: Option[Boolean])
-final case class S3Config(bucketRegion: String, bucketName: String, bucketDir: String, api: S3ApiConfig, uploadEnabled: Boolean)
+final case class S3Config(
+  bucketRegion: String,
+  bucketName: String,
+  bucketDir: String,
+  api: S3ApiConfig,
+  uploadEnabled: Boolean,
+  uploadStateEnabled: Boolean,
+  uploadCombinedEnabled: Boolean,
+  retentionCount: Int
+)
 
 final case class OpenSearchConfig(uri: Uri, bulkSize: Int, indexes: IndexesConfig)
 

--- a/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
@@ -150,10 +150,34 @@ object SnapshotProcessor {
             .handleErrorWith(s => logger.error(s)("Error in database layer") >> s.raiseError[F, Unit])
       }
 
-    private def storeInS3(globalSnapshotWithState: GlobalSnapshotWithState, hasher: Hasher[F]) =
-      s3DAO
-        .uploadSnapshot(globalSnapshotWithState.snapshot, hasher.getLogic(globalSnapshotWithState.snapshot.ordinal))
-        .void
+    private def storeInS3(globalSnapshotWithState: GlobalSnapshotWithState, hasher: Hasher[F]): F[Unit] = {
+      val s3Cfg = configuration.s3
+      val snapshot = globalSnapshotWithState.snapshot
+      val state = globalSnapshotWithState.snapshotInfo
+      val ordinal = snapshot.ordinal
+      val retention = s3Cfg.retentionCount.toLong
+      val expireOrdinal: Option[SnapshotOrdinal] =
+        if (retention > 0L && ordinal.value.value > retention) SnapshotOrdinal(ordinal.value.value - retention)
+        else None
+
+      val uploadSnapshotF = s3DAO
+        .uploadSnapshot(snapshot, hasher.getLogic(ordinal))
+        .whenA(s3Cfg.uploadEnabled)
+      val uploadStateF = s3DAO.uploadState(snapshot, state).whenA(s3Cfg.uploadStateEnabled)
+      val uploadCombinedF = s3DAO
+        .uploadCombined(SnapshotWithState(snapshot, state))
+        .whenA(s3Cfg.uploadCombinedEnabled)
+
+      val pruneStateF = expireOrdinal
+        .traverse_(s3DAO.pruneStatesAtOrdinal)
+        .whenA(s3Cfg.uploadStateEnabled)
+      val pruneCombinedF = expireOrdinal
+        .traverse_(s3DAO.pruneCombinedAtOrdinal)
+        .whenA(s3Cfg.uploadCombinedEnabled)
+
+      (uploadSnapshotF, uploadStateF, uploadCombinedF).parTupled.void >>
+        (pruneStateF, pruneCombinedF).parTupled.void
+    }
 
     private def splitData(globalSnapshotWithState: GlobalSnapshotWithState, d: LocalDateTime, hasher: Hasher[F]) = (
       globalMapper.mapGlobalSnapshot(globalSnapshotWithState, d, txHasher, hasher),
@@ -161,7 +185,7 @@ object SnapshotProcessor {
     ).tupled
 
     private def store(globalSnapshotWithState: GlobalSnapshotWithState, hasher: Hasher[F]): F[Unit] =
-      storeInS3(globalSnapshotWithState, hasher).whenA(configuration.s3.uploadEnabled) >> Clock[F].realTime.map { d =>
+      storeInS3(globalSnapshotWithState, hasher) >> Clock[F].realTime.map { d =>
           val instant = Instant.ofEpochMilli(d.toMillis)
           LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
         }.flatMap(splitData(globalSnapshotWithState, _, hasher))

--- a/src/main/scala/org/constellation/snapshotstreaming/s3/S3DAO.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/s3/S3DAO.scala
@@ -4,25 +4,35 @@ import cats.Applicative
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.{ListObjectsV2Request, ObjectMetadata}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import io.circe.syntax._
 import io.constellationnetwork.ext.kryo._
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.kryo.KryoSerializer
-import io.constellationnetwork.schema.GlobalIncrementalSnapshot
+import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo, SnapshotOrdinal}
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.Hashed
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import fs2.{Stream, io}
+import org.constellation.snapshotstreaming.storage.SnapshotWithState
 import org.constellation.snapshotstreaming.{S3Config, retryF}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+import scala.jdk.CollectionConverters._
 
 trait S3DAO[F[_]] {
   def uploadSnapshot(snapshot: Hashed[GlobalIncrementalSnapshot], hashLogic: HashLogic): F[Unit]
+  def uploadState(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit]
+  def uploadCombined(snapshotWithState: SnapshotWithState): F[Unit]
   def downloadSnapshot(hash: Hash): F[Signed[GlobalIncrementalSnapshot]]
+  def downloadState(ordinal: SnapshotOrdinal, hash: Hash): F[GlobalSnapshotInfo]
+  def downloadCombined(ordinal: SnapshotOrdinal, hash: Hash): F[SnapshotWithState]
+  def pruneStatesAtOrdinal(ordinal: SnapshotOrdinal): F[Unit]
+  def pruneCombinedAtOrdinal(ordinal: SnapshotOrdinal): F[Unit]
   def metadata(hash: Hash): F[ObjectMetadata]
 }
 
@@ -51,6 +61,63 @@ object S3DAO {
 
     private implicit val logger = Slf4jLogger.getLogger[F]
 
+    private def statesPrefix = s"${config.bucketDir}/states/"
+    private def combinedPrefix = s"${config.bucketDir}/combined/"
+    private def stateKey(ordinal: SnapshotOrdinal, hash: Hash) = s"$statesPrefix${ordinal.value.value}-$hash"
+    private def combinedKey(ordinal: SnapshotOrdinal, hash: Hash) = s"$combinedPrefix${ordinal.value.value}-$hash"
+
+    private def gzip(bytes: Array[Byte]): Array[Byte] = {
+      val baos = new ByteArrayOutputStream()
+      val gzos = new GZIPOutputStream(baos)
+      try gzos.write(bytes)
+      finally gzos.close()
+      baos.toByteArray
+    }
+
+    private def gunzip(bytes: Array[Byte]): Array[Byte] = {
+      val in = new GZIPInputStream(new ByteArrayInputStream(bytes))
+      try in.readAllBytes()
+      finally in.close()
+    }
+
+    private def buildMetadata(snapshot: Hashed[GlobalIncrementalSnapshot], bytes: Array[Byte]): ObjectMetadata = {
+      val md = new ObjectMetadata()
+      md.setContentLength(bytes.length.toLong)
+      md.setContentEncoding("gzip")
+      md.setContentType("application/json")
+      md.addUserMetadata("ordinal", snapshot.ordinal.value.value.toString)
+      md.addUserMetadata("hash", snapshot.hash.value)
+      md
+    }
+
+    private def putBytes(key: String, payload: Array[Byte], metadata: ObjectMetadata): F[Unit] =
+      Async[F].delay {
+        val is = new ByteArrayInputStream(payload)
+        s3Client.putObject(config.bucketName, key, is, metadata)
+      }.void
+
+    private def getBytes(key: String): F[Array[Byte]] = {
+      val resource = for {
+        s3Object <- Resource.eval(Async[F].delay(s3Client.getObject(config.bucketName, key)))
+        dataStreamR <- Resource.fromAutoCloseable(Async[F].delay(s3Object.getObjectContent))
+      } yield dataStreamR
+      Stream
+        .resource(resource)
+        .flatMap(inputStream => io.readInputStream(Async[F].delay(inputStream.getDelegateStream), chunkSize = 4096))
+        .compile
+        .to(Array)
+    }
+
+    private def listKeysWithPrefix(prefix: String): F[List[String]] =
+      Async[F].delay {
+        val req = new ListObjectsV2Request().withBucketName(config.bucketName).withPrefix(prefix)
+        val result = s3Client.listObjectsV2(req)
+        result.getObjectSummaries.asScala.toList.map(_.getKey)
+      }
+
+    private def deleteKeys(keys: List[String]): F[Unit] =
+      keys.traverse_(k => Async[F].delay(s3Client.deleteObject(config.bucketName, k)))
+
     def uploadSnapshot(snapshot: Hashed[GlobalIncrementalSnapshot], hashLogic: HashLogic): F[Unit] =
       retryF(for {
         arr <- hashLogic match {
@@ -64,6 +131,32 @@ object S3DAO {
           s"Snapshot ${snapshot.ordinal.value.value} (hash: ${snapshot.hash.show.take(8)}) uploaded to s3."
         )
       } yield ())
+
+    def uploadState(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] =
+      retryF(for {
+        json <- jsonSerializer.serialize(state)
+        compressed <- Async[F].delay(gzip(json))
+        key = stateKey(snapshot.ordinal, snapshot.hash)
+        md = buildMetadata(snapshot, compressed)
+        _ <- putBytes(key, compressed, md)
+        _ <- logger.info(
+          s"State for snapshot ${snapshot.ordinal.value.value} (hash: ${snapshot.hash.show.take(8)}) uploaded to s3."
+        )
+      } yield ())
+
+    def uploadCombined(snapshotWithState: SnapshotWithState): F[Unit] = {
+      val snapshot = snapshotWithState.snapshot
+      retryF(for {
+        json <- Async[F].delay(snapshotWithState.asJson.noSpaces.getBytes("UTF-8"))
+        compressed <- Async[F].delay(gzip(json))
+        key = combinedKey(snapshot.ordinal, snapshot.hash)
+        md = buildMetadata(snapshot, compressed)
+        _ <- putBytes(key, compressed, md)
+        _ <- logger.info(
+          s"Combined (snapshot+state) ${snapshot.ordinal.value.value} (hash: ${snapshot.hash.show.take(8)}) uploaded to s3."
+        )
+      } yield ())
+    }
 
     def downloadSnapshot(hash: Hash): F[Signed[GlobalIncrementalSnapshot]] = {
       val keyName = s"${config.bucketDir}/${hash}"
@@ -79,6 +172,33 @@ object S3DAO {
         .flatMap(d => d.fromBinaryF[Signed[GlobalIncrementalSnapshot]])
 
     }
+
+    def downloadState(ordinal: SnapshotOrdinal, hash: Hash): F[GlobalSnapshotInfo] =
+      for {
+        compressed <- getBytes(stateKey(ordinal, hash))
+        json <- Async[F].delay(gunzip(compressed))
+        either <- jsonSerializer.deserialize[GlobalSnapshotInfo](json)
+        state <- either.liftTo[F]
+      } yield state
+
+    def downloadCombined(ordinal: SnapshotOrdinal, hash: Hash): F[SnapshotWithState] =
+      for {
+        compressed <- getBytes(combinedKey(ordinal, hash))
+        json <- Async[F].delay(gunzip(compressed))
+        parsed <- Async[F].fromEither(_root_.io.circe.parser.decode[SnapshotWithState](new String(json, "UTF-8")))
+      } yield parsed
+
+    def pruneStatesAtOrdinal(ordinal: SnapshotOrdinal): F[Unit] =
+      listKeysWithPrefix(s"$statesPrefix${ordinal.value.value}-").flatMap { keys =>
+        deleteKeys(keys) >>
+          logger.info(s"Pruned ${keys.size} state object(s) at ordinal ${ordinal.value.value} from s3.").whenA(keys.nonEmpty)
+      }
+
+    def pruneCombinedAtOrdinal(ordinal: SnapshotOrdinal): F[Unit] =
+      listKeysWithPrefix(s"$combinedPrefix${ordinal.value.value}-").flatMap { keys =>
+        deleteKeys(keys) >>
+          logger.info(s"Pruned ${keys.size} combined object(s) at ordinal ${ordinal.value.value} from s3.").whenA(keys.nonEmpty)
+      }
 
     def metadata(hash: Hash) =
       Async[F].delay(s3Client.getObjectMetadata(config.bucketName, s"${config.bucketDir}/${hash}"))


### PR DESCRIPTION
## Summary

Snapshot-streaming currently uploads only the raw incremental snapshot to S3. That is not sufficient to support node rollback: both the `GlobalSnapshotInfo` (state) and the combined snapshot+state bundle are required to validate and restore. Two production incidents — nodes missing snapshots, and the streaming DB getting stuck on inserts — both benefit from having the last N states reliably retrievable from S3.

- Uploads **state** (`GlobalSnapshotInfo`) and **combined** (`SnapshotWithState`) to S3 alongside the existing snapshot upload. Each upload is independently toggled.
- Keeps the last `retentionCount` of each (default `1000`) via exact-prefix pruning on the expired ordinal — O(1) per upload, no full bucket scan.
- Key scheme `states/{ordinal}-{hash}` and `combined/{ordinal}-{hash}`: ordinal enables cheap retention, hash prevents fork collisions. S3 object user-metadata carries both `ordinal` and `hash` for tooling.
- Payloads are gzipped JSON (state is ~9.5 MB uncompressed).
- `downloadState(ordinal, hash)` / `downloadCombined(ordinal, hash)` exposed on `S3DAO` for future rollback verification callers.

## Config

New fields under `snapshotStreaming.s3` (all default to off / safe values):

```hocon
s3 {
  uploadEnabled = false          # existing — raw snapshot
  uploadStateEnabled = false     # new — GlobalSnapshotInfo
  uploadCombinedEnabled = false  # new — SnapshotWithState (rollback bundle)
  retentionCount = 1000          # new — lastN kept for state + combined
}
```

## Files changed

- `src/main/scala/org/constellation/snapshotstreaming/Configuration.scala`
- `src/main/scala/org/constellation/snapshotstreaming/s3/S3DAO.scala`
- `src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala`
- `src/main/resources/reference.conf`

## Out of scope / follow-ups

- **Rollback verification call site.** `downloadState` / `downloadCombined` are exposed but no consumer wires them in. The ticket's "ensure via S3 download that state/ordinal/hash match" is presumably handled by the network-monitoring service that triggers the rollback.
- **Backfill of pre-existing ordinals.** Retention only kicks in on new uploads, so flipping the flags on a running stream at ordinal N populates S3 forward only; nothing below `N - retentionCount` is ever written. Matches "store lastN going forward." Happy to add a one-shot backfill if needed.

## Test plan

- [ ] CI passes (develop pulls a snapshot tessellation artifact that is not locally cached; CI resolves from the internal repo)
- [ ] Deploy to a non-production env with `uploadStateEnabled = true` and `uploadCombinedEnabled = true`, `retentionCount = 100` for quick verification
- [ ] Confirm `states/{ordinal}-{hash}` and `combined/{ordinal}-{hash}` objects appear with correct user-metadata
- [ ] After streaming >100 snapshots, confirm the oldest ordinals are pruned from both prefixes
- [ ] Download a combined object, gunzip, confirm JSON round-trips into `SnapshotWithState` and that ordinal/hash match the object key