### PR TITLE
fix: S3 prune failures must not crash the snapshot consumer

### DIFF
--- a/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
@@ -171,9 +171,11 @@ object SnapshotProcessor {
       val pruneStateF = expireOrdinal
         .traverse_(s3DAO.pruneStatesAtOrdinal)
         .whenA(s3Cfg.uploadStateEnabled)
+        .handleErrorWith(e => logger.warn(e)("S3 state prune failed; continuing."))
       val pruneCombinedF = expireOrdinal
         .traverse_(s3DAO.pruneCombinedAtOrdinal)
         .whenA(s3Cfg.uploadCombinedEnabled)
+        .handleErrorWith(e => logger.warn(e)("S3 combined prune failed; continuing."))
 
       (uploadSnapshotF, uploadStateF, uploadCombinedF).parTupled.void >>
         (pruneStateF, pruneCombinedF).parTupled.void


### PR DESCRIPTION
## Problem

Observed in integrationnet after enabling state/combined uploads (#121):

```
Consumer: unrecoverable error processing snapshot SnapshotReference(...5422634...)
AmazonS3Exception: ... is not authorized to perform: s3:ListBucket ...
```

Root cause: the IAM role lacked ListBucket/DeleteObject, so pruning threw. Because \`storeInS3\` chained \`uploads >> prunes\` inside a \`retryF\` wrapper, a prune failure caused the whole \`process\` to retry — re-uploading snapshot + state + combined each attempt — and after retries exhausted, the consumer died and the app crashed.

Log pattern confirms this: the same ordinal (\`5422634\`) shows each of the three objects uploaded successfully 4–5 times back-to-back, one per retry attempt, before the final error.

## Fix

Swallow prune errors with a WARN. Pruning is best-effort: a failed delete leaves extra storage, never data gaps. Uploads still halt on failure (via \`retryF\` in the upload methods themselves), which remains the correct semantic — a missing state/combined object defeats rollback.

After this change, the same IAM-misconfig scenario would:
1. Uploads succeed,
2. Prune warning logged,
3. Consumer moves on to the next snapshot.

Once the IAM policy is fixed, prunes start succeeding and retention catches up on the next upload cycle (each upload tries to prune ordinal-retentionCount).

## Separately needed (not in this PR)

The IAM role needs \`s3:ListBucket\` (conditioned on the \`states/\` and \`combined/\` prefixes) and \`s3:DeleteObject\` on those prefixes. Without it, retention won't actually clean up — but with this PR, the streamer will at least keep running.

## Test plan

- [ ] CI passes
- [ ] Deploy to integrationnet with current (insufficient) IAM policy — confirm consumer does NOT die, WARN is logged per snapshot
- [ ] Update IAM policy on integrationnet — confirm WARN stops, old ordinals get pruned