### PR TITLE
fix: validate post-sub-trie-roots state proofs, bump tessellation to 4.1.0-rc.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val logstash = "7.2"
     val organizeImports = "0.6.0"
     val refined = "0.10.1"
-    val tessellation = "4.0.0-rc.5"
+    val tessellation = "4.1.0-rc.0"
     val weaver = "0.8.1"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val logstash = "7.2"
     val organizeImports = "0.6.0"
     val refined = "0.10.1"
-    val tessellation = "4.1.0-rc.0"
+    val tessellation = "4.1.0-rc.4"
     val weaver = "0.8.1"
   }
 

--- a/src/main/scala/org/constellation/snapshotstreaming/App.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/App.scala
@@ -31,8 +31,30 @@ object App extends IOApp {
             KryoSerializer.forAsync[IO](shared.sharedKryoRegistrar).use { implicit ks =>
               JsonSerializer.forAsync[IO].asResource.use { implicit jsonSerializer =>
                 val hashSelect = makeHashSelect(appConfig, sharedCfg)
+                // `subTrieRootsActivationOrdinal` MUST be passed. It defaults to MaxValue (sub-trie
+                // roots OFF), and `sub-trie-roots` is the only fields-added gate that changes the
+                // SIGNED GlobalSnapshotStateProof, which this indexer independently re-derives and
+                // validates. With gl0 signing roots ON and this selector OFF, every post-activation
+                // ordinal fails `StateProof Broken` on the sub-trie fields and nothing is indexed.
+                // Mirrors gl0's own construction in TessellationIOApp.
+                // Resolved into named vals so the values LOGGED are byte-identical to the values
+                // USED -- a diagnostic that recomputes them can disagree with the selector.
+                val ssEnv = appConfig.snapshotStreaming.environment
+                val lastLegacyOrd =
+                  sharedCfg.lastLegacyStateProofOrdinal.getOrElse(ssEnv, SnapshotOrdinal.MinValue)
+                val subTrieOrd =
+                  sharedCfg.fieldsAddedOrdinals.subTrieRoots.getOrElse(ssEnv, SnapshotOrdinal.MaxValue)
+                // println, not the IO logger: these are plain vals outside the IO chain, so an
+                // unsequenced logger.info would never run. stdout is captured by journald.
+                println(
+                  s"[STATE-PROOF-SELECTOR] env=$ssEnv " +
+                    s"lastLegacyStateProofOrdinal=${lastLegacyOrd.value.value} " +
+                    s"subTrieRootsActivationOrdinal=${subTrieOrd.value.value} " +
+                    s"subTrieRootsKeys=${sharedCfg.fieldsAddedOrdinals.subTrieRoots.keys.mkString(",")} " +
+                    s"lastLegacyKeys=${sharedCfg.lastLegacyStateProofOrdinal.keys.mkString(",")}"
+                )
                 implicit val gsps: GlobalStateProofSelector =
-                  GlobalStateProofSelector(sharedCfg.lastLegacyStateProofOrdinal.getOrElse(appConfig.snapshotStreaming.environment, SnapshotOrdinal.MinValue))
+                  GlobalStateProofSelector(lastLegacyOrd, subTrieOrd)
                 implicit val csps: CurrencyStateProofSelector = CurrencyStateProofSelector.instance
                 implicit val hasherSelector =
                   HasherSelector.forSync[IO](Hasher.forJson[IO], Hasher.forKryo[IO], hashSelect)

--- a/src/main/scala/org/constellation/snapshotstreaming/AppS3.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/AppS3.scala
@@ -34,8 +34,16 @@ object AppS3 extends IOApp {
                 val hashSelect = makeHashSelect(appConfig, sharedCfg)
                 implicit val hasherSelector =
                   HasherSelector.forSync[IO](Hasher.forJson[IO], Hasher.forKryo[IO], hashSelect)
+                // Must pass `subTrieRootsActivationOrdinal` -- it defaults to MaxValue (OFF), and
+                // `sub-trie-roots` changes the SIGNED GlobalSnapshotStateProof this indexer
+                // re-derives. Kept identical to App.scala so the two entry points cannot drift.
                 implicit val gsps: GlobalStateProofSelector =
-                  GlobalStateProofSelector(sharedCfg.lastLegacyStateProofOrdinal.getOrElse(appConfig.snapshotStreaming.environment, SnapshotOrdinal.MinValue))
+                  GlobalStateProofSelector(
+                    sharedCfg.lastLegacyStateProofOrdinal
+                      .getOrElse(appConfig.snapshotStreaming.environment, SnapshotOrdinal.MinValue),
+                    sharedCfg.fieldsAddedOrdinals.subTrieRoots
+                      .getOrElse(appConfig.snapshotStreaming.environment, SnapshotOrdinal.MaxValue)
+                  )
                 implicit val csps: CurrencyStateProofSelector = CurrencyStateProofSelector.instance
                 val txHasher = Hasher.forKryo[IO]
 

--- a/src/main/scala/org/constellation/snapshotstreaming/Configuration.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/Configuration.scala
@@ -125,7 +125,6 @@ object Configuration {
       c.priorityPeerIds.get(env),
       c.snapshot.size,
       c.feeConfigs.get(env).map(SortedMap.from(_)).getOrElse(SortedMap.empty),
-      c.forkInfoStorage,
       c.lastKryoHashOrdinal,
       c.lastLegacyStateProofOrdinal,
       c.incrementalDelegatedStakingStartingOrdinal,

--- a/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/SnapshotProcessor.scala
@@ -22,13 +22,12 @@ import io.constellationnetwork.node.shared.http.p2p.clients.L0GlobalSnapshotClie
 import io.constellationnetwork.node.shared.infrastructure.cluster.storage.L0ClusterStorage
 import io.constellationnetwork.schema.SnapshotReference.{fromHashedSnapshot => getSnapshotReference}
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.{CurrencyStateProofSelector, GlobalIncrementalSnapshot, GlobalSnapshot, GlobalSnapshotInfo, GlobalSnapshotInfoV2, GlobalSnapshotStateProof, GlobalStateProofSelector, SnapshotOrdinal}
+import io.constellationnetwork.schema.{CurrencyStateProofSelector, GlobalIncrementalSnapshot, GlobalSnapshot, GlobalSnapshotInfo, GlobalSnapshotInfoV2, GlobalStateProofSelector, SnapshotOrdinal}
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.statechannel.StateChannelSnapshotBinary
 import io.constellationnetwork.schema.mpt.GlobalStateConverter.syntax.GlobalSnapshotInfoMptOps
 import io.constellationnetwork.schema.mpt.{GlobalStateKey, MptStore}
-import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.mpt.MptRoot
 import io.constellationnetwork.security.mpt.producer.FileSystemMerklePatriciaProducer
 import io.constellationnetwork.validator.StateProofValidator
@@ -210,30 +209,25 @@ object SnapshotProcessor {
               )
 
               result <- if( snapshot.ordinal > sharedConfigReader.lastLegacyStateProofOrdinal.getOrElse(configuration.environment, SnapshotOrdinal.MinValue)){
-                val stateProof = GlobalSnapshotStateProof
-                  .apply(
-                    Hash.empty,
-                    Hash.empty,
-                    Hash.empty,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(mptRoot.value)
-                  )
-                logger.info(
-                  s"Validating mptProof for ordinal ${snapshot.ordinal.value.value}"
-                ) >>
-                StateProofValidator.validateProof(snapshot, stateProof)
+                // Use the SDK's assembly instead of hand-building the proof. This branch previously
+                // built an mptRoot-only literal (Hash.empty x3, None x13, Some(mptRoot)). That was
+                // correct while an MPT-format proof WAS mptRoot-only, but `sub-trie-roots` makes gl0
+                // sign per-field sub-trie roots in the otherwise-None fields, so the literal
+                // mismatches every post-activation ordinal on 16 of 17 fields (only mptRoot agreed)
+                // -> `StateProof Broken` chain-wide and 0 snapshots indexed.
+                //
+                // `assembleMptProof` is EXACTLY equivalent pre-activation -- its else-branch is that
+                // same literal. Post-activation it derives the sub-trie roots from `snapshotInfo`,
+                // honoring `GlobalStateProofSelector.subTrieRootsEnabled`. mptRoot still comes from
+                // the pre-built producer trie via `mptRoot`, unchanged.
+                GlobalSnapshotInfo
+                  .assembleMptProof[F](snapshotInfo, snapshot.ordinal, mptRoot.value)
+                  .flatMap { stateProof =>
+                    logger.info(
+                      s"Validating mptProof for ordinal ${snapshot.ordinal.value.value}"
+                    ) >>
+                      StateProofValidator.validateProof(snapshot, stateProof)
+                  }
               } else {
                 validator.validate(snapshot, snapshotInfo)
               }

--- a/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/TessellationServices.scala
@@ -107,7 +107,7 @@ object TessellationServices {
                 validationErrorStorage
               )
             val currencySnapshotValidator = CurrencySnapshotValidator
-              .make[F](tessellation3Migration, currencySnapshotCreator, SignedValidator.make[F], None, None)
+              .make[F](currencySnapshotCreator, SignedValidator.make[F], None, None)
             CurrencySnapshotContextFunctions.make(currencySnapshotValidator)
           }
         }
@@ -123,7 +123,10 @@ object TessellationServices {
             validators.stateChannelValidator,
             stateChannelManager,
             currencySnapshotContextFns,
-            feeCalculator
+            feeCalculator,
+            mptStore,
+            configuration.fieldsAddedOrdinals,
+            env
           )
         val priceOracle = configuration.priceOracle.getOrElse(env, PriceOracleConfig.default)
         val globalSnapshotAcceptanceManager: GlobalSnapshotAcceptanceManager[F] = GlobalSnapshotAcceptanceManager.make(

--- a/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
+++ b/src/main/scala/org/constellation/snapshotstreaming/storage/FileBasedLastGlobalIncrementalSnapshotStorage.scala
@@ -117,6 +117,21 @@ object FileBasedLastGlobalIncrementalSnapshotStorage {
 
       def getHeight: F[Option[Height]] = get.map(_.map(_.height))
 
+      def setForRecovery(snapshot: Hashed[GlobalIncrementalSnapshot], state: GlobalSnapshotInfo): F[Unit] = {
+        val snapshotWithState = SnapshotWithState(snapshot, state)
+        saveSnapshotWithStateJson(path, snapshotWithState) >> cachedSnapshot.set(Some(snapshotWithState))
+      }
+
+      def clear: F[Unit] = {
+        val backupPath = Path(path.toString + ".bk")
+        val deleteFile = (p: Path) =>
+          Files[F].deleteIfExists(p).void.handleErrorWith {
+            case _: java.nio.file.NoSuchFileException => Async[F].unit
+            case e                                    => Async[F].raiseError(e)
+          }
+        cachedSnapshot.set(None) >> deleteFile(path) >> deleteFile(backupPath)
+      }
+
     }
 
 }


### PR DESCRIPTION
## Summary

Brings snapshot-streaming `release/integrationnet` onto the v4.1.0 SDK line and fixes the state-proof
bug that took the IntegrationNet indexer down for roughly two hours on 2026-08-10. `sub-trie-roots` is
the only `fields-added-ordinals` gate that changes the **signed** `GlobalSnapshotStateProof`, which this
indexer independently re-derives and validates. IntegrationNet crossed its activation ordinal
**5,880,000** and the indexer then rejected **every** global snapshot from that ordinal on -- `StateProof
Broken`, 16 of 17 fields differing, agreeing only on `mptRoot` -- storing nothing to S3, OpenSearch or
Postgres.

Root cause: `SnapshotProcessor` **hand-built** the proof as an mptRoot-only literal and never consulted
the state-proof selector, so it could only ever produce the not-activated shape.

**Testnet and mainnet will fail identically when their gates activate.** Both are still `9999999`. See
the pre-activation checklist at the bottom.

## Changes

* **Modified** - `SnapshotProcessor.scala`: **the fix.** Replace the hand-built proof literal
  (`Hash.empty` x3, `None` x13, `Some(mptRoot)`) with
  `GlobalSnapshotInfo.assembleMptProof[F](snapshotInfo, snapshot.ordinal, mptRoot.value)`.
  `assembleMptProof`'s else-branch **is** that same literal, so pre-activation behavior is
  byte-identical; post-activation it derives the per-field sub-trie roots from `snapshotInfo`, honoring
  `GlobalStateProofSelector.subTrieRootsEnabled`. `mptRoot` still comes from the pre-built producer trie,
  unchanged.
* **Modified** - `App.scala`: two-argument `GlobalStateProofSelector(lastLegacyOrd, subTrieOrd)`, plus a
  startup line reporting the resolved ordinals and the config map keys. Necessary but on its own inert,
  because the validator never consulted the selector -- see the diagnostic note below.
* **Modified** - `AppS3.scala`: the same two-argument fix. `AppS3` is a **second** `IOApp` entry point
  (the build prints `multiple main classes detected`); correcting only `App` leaves the two able to
  drift.
* **Modified** - `project/Dependencies.scala`: tessellation-sdk `4.1.0-rc.0` -> `4.1.0-rc.4`.
  IntegrationNet moved to rc.4 on 08-07 while the deployed jar was still built against rc.0.
* **Removed** - now-unused `GlobalSnapshotStateProof` and `Hash` imports (scalafix has
  `removeUnused = true`).

Earlier commit on this branch, unchanged from the original PR: the `4.0.0-rc.5 -> 4.1.0-rc.0` bump and
its four SDK adaptations (`CurrencySnapshotValidator.make` arity,
`GlobalSnapshotStateChannelEventsProcessor.make` signature, dropping `forkInfoStorage` from
`nodeSharedConfig`, and the two new `LastSnapshotStorage` members).

## Testing

* `sbt compile` and `sbt assembly` clean against `tessellation-sdk 4.1.0-rc.4` (Maven Central).
* **Verified live on IntegrationNet** (52.53.243.4). After the 16:31:54 UTC restart: zero `StateProof
  Broken`, zero `State broken` warnings, zero errors. Backfill resumed at exactly the activation
  ordinal and validated 5,880,000 through 5,880,031, ending in `Snapshot 5880031 ... sent to postgres`.
* The startup line confirmed configuration was correct all along, which is what isolated the fault:

  ```
  [STATE-PROOF-SELECTOR] env=Integrationnet lastLegacyStateProofOrdinal=5075000
    subTrieRootsActivationOrdinal=5880000
    subTrieRootsKeys=Dev,Integrationnet,Mainnet,Testnet
    lastLegacyKeys=Testnet,Dev,Integrationnet,Mainnet
  ```

  A populated acceptance trace next to an **empty** validator proof at the same ordinal means two code
  paths in the consumer, not two configurations. `println` rather than `logger.info` because these are
  plain vals outside the `IO` chain, so an unsequenced `logger.info` would never run; stdout is captured
  by journald.
* **No unit test added.** Nothing in this repo currently catches a hand-built proof drifting from the
  SDK's assembly. A regression test asserting the validator's proof equals `assembleMptProof` output for
  an ordinal at or after an activation ordinal is the obvious follow-up, and worth doing before the
  mainnet gate.
* **CI note:** `pull_request.yml` is stale and cannot pass on any 4.1.x pin. It targets the retired
  `ubuntu-20.04` runner label, so the job never gets scheduled -- the run on this PR sat queued exactly
  24h and was then `CANCELLED`, before these commits. Even if it were scheduled, it checks out
  tessellation `v2.12.0` and sets up Java 11, while the 4.1.x SDK requires Java 21. Worth a separate PR
  to modernise; deliberately out of scope for a hotfix.

## Pre-activation checklist for testnet and mainnet

Both nets still carry `sub-trie-roots: 9999999`. When either is scheduled to activate:

1. Deploy a snapshot-streaming jar containing **all three** source changes above **before** the gate
   ordinal, in the same coordinated cold restart as the node software.
2. Confirm the startup line reads `subTrieRootsActivationOrdinal=<that net's gate>`, not
   `9223372036854775807` (`MaxValue`, the silent default that means OFF).
3. Diff **every** `fields-added-ordinals` gate on the box against the tessellation release. The box's own
   `application.conf` cannot inherit SDK defaults: Typesafe Config auto-loads `reference.conf` from every
   jar but only one `application.conf`, and the SDK ships its gate defaults in `application.conf`, so
   each consumer must restate them.
4. Only then let the chain cross the ordinal.

Longer-term, moving those gate defaults to `reference.conf` in the SDK would remove step 3 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
